### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/EnglishVersion/README_English.md
+++ b/EnglishVersion/README_English.md
@@ -17,7 +17,7 @@ _or_
 #### 一、good plugin  
 1. Android ButterKnife Zelezny  
 ButterKnife is a focus on the Android system View into the framework, and can reduce a lot of the findViewById setOnClickListener code, visualization of a key generation.  
-####PS:Please open the link to see the effect.  
+#### PS:Please open the link to see the effect.  
 plugin download url：https://plugins.jetbrains.com/plugin/7369?pr=androidstudio  
 plugin source url： https://github.com/avast/android-butterknife-zelezny  
 plugin tutorials：http://blog.csdn.net/dreamlivemeng/article/details/51261170  

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ _or_
 #### 一、优秀插件  
 1. Android ButterKnife Zelezny  
 ButterKnife是一个专注于Android系统的View注入框架,可以减少大量的findViewById以及setOnClickListener代码，可视化一键生成。
-####PS:效果图就不贴了，打开插件下载地址和源码地址都能看见，而且数据多了加载效果图蛮卡的。  
+#### PS:效果图就不贴了，打开插件下载地址和源码地址都能看见，而且数据多了加载效果图蛮卡的。  
 插件下载地址：https://plugins.jetbrains.com/plugin/7369?pr=androidstudio  
 插件源码地址： https://github.com/avast/android-butterknife-zelezny  
 插件教程：http://blog.csdn.net/dreamlivemeng/article/details/51261170  


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
